### PR TITLE
Implement termux colorschemes

### DIFF
--- a/modules/terminal.nix
+++ b/modules/terminal.nix
@@ -1,36 +1,47 @@
-# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
-
-{ config, lib, ... }:
-
-with lib;
-
-let
+# Copyright (c) 2019-2024, see AUTHORS. Licensed under MIT License, see LICENSE.
+{ config
+, lib
+, pkgs
+, ...
+}:
+with lib; let
   cfg = config.terminal;
 in
-
 {
-
   ###### interface
 
   options = {
-
-    terminal.font = mkOption {
-      default = null;
-      type = types.nullOr types.path;
-      example = lib.literalExpression
-        ''"''${pkgs.terminus_font_ttf}/share/fonts/truetype/TerminusTTF.ttf"'';
-      description = ''
-        Font used for the terminal.
-      '';
+    terminal = {
+      font = mkOption {
+        default = null;
+        type = types.nullOr types.path;
+        example =
+          lib.literalExpression
+            ''"''${pkgs.terminus_font_ttf}/share/fonts/truetype/TerminusTTF.ttf"'';
+        description = ''
+          Font used for the terminal.
+        '';
+      };
+      colors = mkOption {
+        default = { };
+        type = types.lazyAttrsOf types.str;
+        example = lib.literalExpression ''
+          {
+            background = "#000000";
+            foreground = "#FFFFFF";
+            cursor = "#FFFFFF";
+          }
+        '';
+        description = ''
+          Colorscheme used for the terminal.
+        '';
+      };
     };
-
   };
-
 
   ###### implementation
 
   config = {
-
     build.activation =
       let
         fontPath =
@@ -40,9 +51,20 @@ in
         configDir = "${config.user.home}/.termux";
         fontTarget = "${configDir}/font.ttf";
         fontBackup = "${configDir}/font.ttf.bak";
+
+        inherit (lib.generators) toKeyValue;
+
+        colors = pkgs.writeTextFile {
+          name = "colors.properties";
+          text = toKeyValue { } cfg.colors;
+        };
+        colorsTarget = "${configDir}/colors.properties";
+        colorsBackup = "${configDir}/colors.properties.bak";
+        colorsPath = "${config.build.installationDir}/${colors}";
       in
-      if (cfg.font != null) then
-        {
+      (
+        if (cfg.font != null)
+        then {
           linkFont = ''
             $DRY_RUN_CMD mkdir $VERBOSE_ARG -p "${configDir}"
             if [ -e "${fontTarget}" ] && ! [ -L "${fontTarget}" ]; then
@@ -52,8 +74,7 @@ in
             $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${fontPath}" "${fontTarget}"
           '';
         }
-      else
-        {
+        else {
           unlinkFont = ''
             if [ -e "${fontTarget}" ] && [ -L "${fontTarget}" ]; then
               $DRY_RUN_CMD rm $VERBOSE_ARG "${fontTarget}"
@@ -68,6 +89,36 @@ in
               fi
             fi
           '';
-        };
+        }
+      )
+      // (
+        if (cfg.colors != { })
+        then {
+          linkColors = ''
+            $DRY_RUN_CMD mkdir $VERBOSE_ARG -p "${configDir}"
+            if [ -e "${colorsTarget}" ] && ! [ -L "${colorsTarget}" ]; then
+              $DRY_RUN_CMD mv $VERBOSE_ARG "${colorsTarget}" "${colorsBackup}"
+              $DRY_RUN_CMD echo "${colorsTarget} has been moved to ${colorsBackup}"
+            fi
+            $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${colorsPath}" "${colorsTarget}"
+          '';
+        }
+        else {
+          unlinkColors = ''
+            if [ -e "${colorsTarget}" ] && [ -L "${colorsTarget}" ]; then
+              $DRY_RUN_CMD rm $VERBOSE_ARG "${colorsTarget}"
+              if [ -e "${colorsBackup}" ]; then
+                $DRY_RUN_CMD mv $VERBOSE_ARG "${colorsBackup}" "${colorsTarget}"
+                $DRY_RUN_CMD echo "${colorsTarget} has been restored from backup"
+              else
+                if $DRY_RUN_CMD rm $VERBOSE_ARG -d "${configDir}" 2>/dev/null
+                then
+                  $DRY_RUN_CMD echo "removed empty ${configDir}"
+                fi
+              fi
+            fi
+          '';
+        }
+      );
   };
 }

--- a/modules/terminal.nix
+++ b/modules/terminal.nix
@@ -6,6 +6,10 @@
 }:
 with lib; let
   cfg = config.terminal;
+  validColornames =
+    [ "background" "foreground" "cursor" ] ++
+    (builtins.map (n: "color${builtins.toString n}") (lib.lists.range 0 15));
+  validColorname = colorName: builtins.elem colorName validColornames;
 in
 {
   ###### interface
@@ -34,6 +38,8 @@ in
         '';
         description = ''
           Colorscheme used for the terminal.
+          Acceptable attribute names are:
+          `background`, `foreground`, `cursor` and `color0`-`color15`.
         '';
       };
     };
@@ -42,6 +48,14 @@ in
   ###### implementation
 
   config = {
+    assertions = [{
+      assertion = builtins.all validColorname (attrNames cfg.colors);
+      message = ''
+        `terminal.colors` only accepts the following attributes:
+        `background`, `foreground`, `cursor` and `color0`-`color15`.
+      '';
+    }];
+
     build.activation =
       let
         fontPath =

--- a/tests/on-device/config-term-colors.bats
+++ b/tests/on-device/config-term-colors.bats
@@ -1,0 +1,88 @@
+# Copyright (c) 2019-2024, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+load lib
+
+setup() {
+  _setup
+  [[ ! -d $HOME/.termux ]]
+  mkdir $HOME/.termux
+
+  cat > $HOME/.termux/colors.properties.refl <<EOF
+background=#FFFFFF
+color0=#00FF00
+color15=#00FF15
+cursor=#FF0000
+foreground=#000000
+EOF
+  echo 'background = #012345' > $HOME/.termux/colors.properties.refs
+}
+
+teardown() {
+  rm -f $HOME/.termux/colors.properties
+  rm -f $HOME/.termux/colors.properties.refs
+  rm -f $HOME/.termux/colors.properties.refl
+  rm -f $HOME/.termux/colors.properties.bak
+  rm -fd $HOME/.termux
+}
+
+@test 'specifying colors works (no backup)' {
+  [[ ! -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+
+  cp \
+    "$ON_DEVICE_TESTS_DIR/config-term-colors.nix" \
+    ~/.config/nixpkgs/nix-on-droid.nix
+  nix-on-droid switch
+  _diff -u $HOME/.termux/colors.properties $HOME/.termux/colors.properties.refl
+
+  [[ -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+
+  switch_to_default_config
+
+  [[ ! -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+}
+
+@test 'specifying colors works (backup)' {
+  cat $HOME/.termux/colors.properties.refs > $HOME/.termux/colors.properties
+
+  [[ -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+
+  cp \
+    "$ON_DEVICE_TESTS_DIR/config-term-colors.nix" \
+    ~/.config/nixpkgs/nix-on-droid.nix
+  nix-on-droid switch
+
+  [[ -e $HOME/.termux/colors.properties ]]
+  [[ -e $HOME/.termux/colors.properties.bak ]]
+  _diff -u $HOME/.termux/colors.properties $HOME/.termux/colors.properties.refl
+  _diff -u $HOME/.termux/colors.properties.bak \
+    $HOME/.termux/colors.properties.refs
+
+  switch_to_default_config
+
+  [[ -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+}
+
+@test 'specifying a wrong keyword for color fails' {
+  [[ ! -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+
+  cat $HOME/.termux/colors.properties.refs > $HOME/.termux/colors.properties
+  _sed 's|color0|color16|' \
+    "$ON_DEVICE_TESTS_DIR/config-term-colors.nix" \
+    > ~/.config/nixpkgs/nix-on-droid.nix
+  run nix-on-droid switch
+  [[ $status -eq 1 ]]
+  [[ $output =~ \
+    \`terminal.colors\`\ only\ accepts\ the\ following\ attributes: ]]
+
+  switch_to_default_config
+
+  [[ -e $HOME/.termux/colors.properties ]]
+  [[ ! -e $HOME/.termux/colors.properties.bak ]]
+  _diff -u $HOME/.termux/colors.properties $HOME/.termux/colors.properties.refs
+}

--- a/tests/on-device/config-term-colors.nix
+++ b/tests/on-device/config-term-colors.nix
@@ -1,0 +1,12 @@
+_:
+
+{
+  system.stateVersion = "23.05";
+  terminal.colors = {
+    background = "#FFFFFF";
+    foreground = "#000000";
+    cursor = "#FF0000";
+    color0 = "#00FF00";
+    color15 = "#00FF15";
+  };
+}

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2024, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 # call _setup when defining a setup function in your test
 _setup() {
@@ -63,4 +63,10 @@ _sed() {
   local storePath
   storePath="$(nix-build "<nixpkgs>" --no-out-link --attr gnused)"
   "${storePath}/bin/sed" "$@"
+}
+
+_diff() {
+  local storePath
+  storePath="$(nix-build "<nixpkgs>" --no-out-link --attr diffutils)"
+  "${storePath}/bin/diff" "$@"
 }


### PR DESCRIPTION
This implements basic support for termux's colorschemes (`~/.termux/colors.properties`) through the new option `terminal.colors`. It takes an attribute set of strings and naively converts that to the key-value format termux expects, e.g. 
```nix
terminal.colors = rec {
  background = color0;
  foreground = color15;
  cursor = color15;

  color0 = "#000000";
  # color1-14 here :)
  color15 = "#FFFFFF";
};
```
would become 
```
background=#000000
color0=#000000
color15=#FFFFFF
cursor=#FFFFFF
foreground=#FFFFFF
```
I wasn't sure whether to use `attrsOf` or `lazyAttrsOf`, so I chose the latter as a guess.
I've mostly just copied over the implementation from what fonts do, I hope that's correct.

There are a couple issues with this as it stands:
1. Colors aren't strictly checked, you can input any string.
2. Attributes aren't checked, you can input any attribute (whereas I believe termux only ever uses background, foreground, cursor and color0-15).
3. There isn't any option to use a preexisting file.
4. The changes don't immediately apply and require opening a new session, but as I understand it that's blocked by #221.
5. Since both font and colors share most of the same code, maybe it could be pulled out into a separate function/functions?
6. My documentation here could probably be better.

It works enough for my usecase, but there's certainly a lot that could be improved.