### PR TITLE
home-manager: Extend `lib` instead of `pkgs.lib`

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -7,7 +7,7 @@ with lib;
 let
   cfg = config.home-manager;
 
-  extendedLib = import (home-manager-path + "/modules/lib/stdlib-extended.nix") pkgs.lib;
+  extendedLib = import (home-manager-path + "/modules/lib/stdlib-extended.nix") lib;
 
   hmModule = types.submoduleWith {
     specialArgs = { lib = extendedLib; } // cfg.extraSpecialArgs;


### PR DESCRIPTION
This will allow extending `lib` using:

```
_modules.args.lib = ...
```

Without this the extended lib is not available to home-manager modules.

I'm using `_module.args.lib` to [extend](https://github.com/azuwis/nix-config/blob/master/flakes/lib.nix) the `lib`, add `lib.my` functions to all system modules and home-manager modules, it works in both NixOS and nix-darwin, but not in nix-on-droid.

This is also how home-manager [nixos and nix-darwin module](https://github.com/nix-community/home-manager/blob/2939d490366251d9ed5a0bd938275c590a1d6fa6/nixos/common.nix#L12) works.