### PR TITLE
login: Do not dereference proot binds `/bin` and `/etc`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Alexander Sosedkin <monk@unboiled.info>
 Tobias Happ <tobias.happ@gmx.de>
 Bruno Bigras <bigras.bruno@gmail.com>
 Evgeny Kurnevsky <kurnevsky@gmail.com>
+Zhong Jianxin <azuwis@gmail.com>

--- a/modules/environment/login/login.nix
+++ b/modules/environment/login/login.nix
@@ -48,8 +48,8 @@ writeScript "login" ''
 
   exec ${installationDir}/bin/proot-static \
     -b ${installationDir}/nix:/nix \
-    -b ${installationDir}/bin:/bin \
-    -b ${installationDir}/etc:/etc \
+    -b ${installationDir}/bin:/bin! \
+    -b ${installationDir}/etc:/etc! \
     -b ${installationDir}/tmp:/tmp \
     -b ${installationDir}/usr:/usr \
     -b ${installationDir}/dev/shm:/dev/shm \

--- a/tests/emulator/test_channels_shell.py
+++ b/tests/emulator/test_channels_shell.py
@@ -36,8 +36,8 @@ def run(d):
         ('cd /data/data/com.termux.nix/files/home; '
          'pwd; '
          'id; '
-         '/data/data/com.termux.nix/files/usr/bin/login '
-         ' nix-on-droid on-device-test')
+         'env PATH= /data/data/com.termux.nix/files/usr/bin/login '
+         ' nix-on-droid on-device-test'),
     ]:
         print(f'running {cmd} as {user} with capture:')
         p = subprocess.Popen(['adb', 'shell', 'su', '0', 'su', user,


### PR DESCRIPTION
`/bin` and `/etc` are symlinks to `/system/bin` and `/system/etc`, by default proot will dereference and override them with new contents.

After this change, `/system/bin` and `/system/etc` are kept untouched, so commands like `/system/bin/ping` can be run directly.