### PR TITLE
Check if the selected shell is a directory

### DIFF
--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -6,6 +6,12 @@ let
   inherit (initialPackageInfo) cacert nix;
 
   nixCmd = "${nix}/bin/nix --extra-experimental-features 'flakes nix-command'";
+  userShell =
+    if config.user.shell.type or "not-found" == "derivation" then
+      if config.user.shell ? passthru.shellPath then
+        "${config.user.shell}${config.user.shell.passthru.shellPath}"
+      else builtins.abort "Derivation without shell path found at `user.shell`. Use the path to the exact binary."
+    else config.user.shell;
 in
 
 writeText "login-inner" ''
@@ -141,13 +147,18 @@ writeText "login-inner" ''
     exec /usr/bin/env bash  # otherwise it'll be a limited bash that came with Nix
   ''}
 
-  usershell="${config.user.shell}"
+  usershell="${userShell}"
   if [ "$#" -gt 0 ]; then  # if script is not called from within Nix-on-Droid app
     exec /usr/bin/env "$@"
+  elif [ -d "$usershell" ]; then
+    echo "Cannot execute shell '${userShell}', it is a directory."
+    echo "You should point 'user.shell' to the exact binary."
+    echo "Falling back to bash."
+    exec -l bash
   elif [ -x "$usershell" ]; then
     exec -a "-''${usershell##*/}" "$usershell"
   else
-    echo "Cannot execute shell '${config.user.shell}', falling back to bash"
+    echo "Cannot execute shell '${userShell}', falling back to bash"
     exec -l bash
   fi
 ''

--- a/tests/emulator/poke_around.py
+++ b/tests/emulator/poke_around.py
@@ -52,3 +52,46 @@ def run(d):
     d.ui.press('enter')
     wait_for(d, 'This is Zip')
     screenshot(d, 'zip-is-still-there')
+
+    def change_shell_and_relogin(shell, descr):
+        import base64
+        import time
+        config = ('{pkgs, ...}: {user.shell = %SHELL%; ' +
+                  'system.stateVersion = "24.05";}').replace('%SHELL%', shell)
+        config_base64 = base64.b64encode(config.encode()).decode()
+        d(f'input text "echo {config_base64} | base64 -d > '
+          '~/.config/nixpkgs/nix-on-droid.nix"')
+        d.ui.press('enter')
+        screenshot(d, f'pre-switch-{descr}')
+        d(f'input text "nix-on-droid switch && echo switched  {descr}"')
+        d.ui.press('enter')
+        time.sleep(1)
+        screenshot(d, f'in-switch-{descr}')
+        wait_for(d, f'switched {descr}')
+        screenshot(d, f'post-switch-{descr}')
+        d('input text "exit"')
+        d.ui.press('enter')
+        screenshot(d, f'pre-re-login-{descr}')
+        d.app('com.termux.nix').launch()
+        time.sleep(1)
+        screenshot(d, f'post-re-login-{descr}')
+
+    # change shell: pkgs.fish -> fish
+    change_shell_and_relogin('pkgs.fish', 'bare-fish')
+    wait_for(d, 'Welcome to fish, the friendly interactive shell')
+    screenshot(d, 're-login-done-bare-fish')
+
+    # change shell: "${pkgs.fish}", which is a directory -> fallback
+    change_shell_and_relogin('"${pkgs.fish}"', 'fish-directory')
+    wait_for(d, 'Cannot execute shell ')
+    wait_for(d, 'it is a directory.')
+    wait_for(d,
+             "You should point 'user.shell' to the exact binary.")
+    wait_for(d, 'Falling back to bash.')
+    wait_for(d, 'bash-5.2$')
+    screenshot(d, 're-login-done-shell-dir-fallback')
+
+    # change shell: "${pkgs.fish}/bin/fish" -> fish
+    change_shell_and_relogin('"${pkgs.fish}/bin/fish"', 'fish-bin-fish')
+    wait_for(d, 'Welcome to fish, the friendly interactive shell')
+    screenshot(d, 're-login-done-fish-bin-fish')


### PR DESCRIPTION
Setting `user.shell = pkgs.fish` or similar is a common footgun that completely breaks the nix-on-droid. See #284.

This PR try to address the problem by checking that if the shell is a directory and falling back to bash in that case. This fix the common cause that many people hit that issue, but a general fix for that issue should probably include a way to switch generations without using the terminal, since setting the `user.shell` wrongly isn't probably the only way to break nix-on-droid.