### PR TITLE
Install on vanilla termux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709445365,
-        "narHash": "sha256-DVv6nd9FQBbMWbOmhq0KVqmlc3y3FMSYl49UXmMcO+0=",
+        "lastModified": 1732482255,
+        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4de84265d7ec7634a69ba75028696d74de9a44a7",
+        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         "nmt": "nmt"
       },
       "locked": {
-        "lastModified": 1705252799,
-        "narHash": "sha256-HgSTREh7VoXjGgNDwKQUYcYo13rPkltW7IitHrTPA5c=",
+        "lastModified": 1729445390,
+        "narHash": "sha256-TxJ7RZLlBkKWZos1ai3eWIH0fBq1G6SVE+q3dW+0qRU=",
         "owner": "Gerschtli",
         "repo": "nix-formatter-pack",
-        "rev": "2de39dedd79aab14c01b9e2934842051a160ffa5",
+        "rev": "9f4bcf647cad2edafda7e1143071e0daf37cbc41",
         "type": "github"
       },
       "original": {
@@ -46,31 +46,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708172716,
-        "narHash": "sha256-3M94oln0b61m3dUmLyECCA9hYAHXZEszM4saE3CmQO4=",
+        "lastModified": 1732665169,
+        "narHash": "sha256-BWzlDJpfcE7DgxtAkeXHnU69Iz6cU64yCgE6b+hqds8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d874ac46894c896119bce68e758e9e80bdb28f1",
+        "rev": "69661586d1c9d85e859887d95285f6fc92521657",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-docs": {
-      "locked": {
-        "lastModified": 1705957679,
-        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -133,7 +117,9 @@
         "home-manager": "home-manager",
         "nix-formatter-pack": "nix-formatter-pack",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-docs": "nixpkgs-docs",
+        "nixpkgs-docs": [
+          "nixpkgs"
+        ],
         "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap",
         "nmd": "nmd"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       inputs.nmd.follows = "nmd";
     };
 
-    nixpkgs-docs.url = "github:NixOS/nixpkgs/release-23.05";
+    nixpkgs-docs.follows = "nixpkgs";
 
     nmd = {
       url = "sourcehut:~rycee/nmd";

--- a/modules/build/config.nix
+++ b/modules/build/config.nix
@@ -43,7 +43,7 @@ with lib;
 
   config = {
 
-    build.installationDir = "/data/data/com.termux/files/usr";
+    build.installationDir = "/data/data/com.termux/files/nix";
 
   };
 

--- a/modules/build/config.nix
+++ b/modules/build/config.nix
@@ -43,7 +43,7 @@ with lib;
 
   config = {
 
-    build.installationDir = "/data/data/com.termux.nix/files/usr";
+    build.installationDir = "/data/data/com.termux/files/usr";
 
   };
 

--- a/modules/environment/login/login.nix
+++ b/modules/environment/login/login.nix
@@ -46,6 +46,11 @@ writeScript "login" ''
     BIND_PROC_UPTIME=""
   fi
 
+  # See https://github.com/CypherpunkArmory/UserLAnd/issues/1333
+  unset LD_LIBRARY_PATH
+  unset LD_PRELOAD
+
+
   exec ${installationDir}/bin/proot-static \
     -b ${installationDir}/nix:/nix \
     -b ${installationDir}/bin:/bin! \

--- a/modules/user.nix
+++ b/modules/user.nix
@@ -91,7 +91,7 @@ in
 
     user = {
       group = "nix-on-droid";
-      home = "/data/data/com.termux.nix/files/home";
+      home = "/data/data/com.termux/files/home";
       userName = "nix-on-droid";
     };
 

--- a/pkgs/bootstrap-zip.nix
+++ b/pkgs/bootstrap-zip.nix
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2024, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ lib, runCommand, zip, bootstrap, targetSystem }:
+{ lib, runCommand, gnutar, bootstrap, targetSystem }:
 
 let
   arch = lib.strings.removeSuffix "-linux" targetSystem;
@@ -8,5 +8,5 @@ in
 runCommand "bootstrap-zip" { } ''
   mkdir $out
   cd ${bootstrap}
-  ${zip}/bin/zip -q -9 -r $out/bootstrap-${arch} ./* ./.l2s
+  ${gnutar}/bin/tar czf $out/bootstrap-${arch}.tar.gz ./* ./.l2s
 ''

--- a/pkgs/bootstrap.nix
+++ b/pkgs/bootstrap.nix
@@ -22,13 +22,4 @@ runCommand "bootstrap" { } ''
   cp --dereference --recursive $out/etc/static $out/etc/.static.tmp
   rm $out/etc/static
   mv $out/etc/.static.tmp $out/etc/static
-
-  find $out -executable -type f | sed s@^$out/@@ > $out/EXECUTABLES.txt
-
-  find $out -type l | while read -r LINK; do
-    LNK=''${LINK#$out/}
-    TGT=$(readlink "$LINK")
-    echo "$TGT←$LNK" >> $out/SYMLINKS.txt
-    rm "$LINK"
-  done
 ''


### PR DESCRIPTION
This PR is incomplete, instead we should create another bootstrap zip for termux specifically while respecting existing nix-on-droid-app code contract. 

I created a PR here to show you @t184256 the only working bootstrap zip for termux, after 2+ hours of manual cross-compilation from my machine to scp it and set it up on the android device:

```sh
[pc:~/nix-on-droid]$ NIX_ON_DROID_CHANNEL_URL=https://github.com/KoviRobi/nix-on-droid/archive/refs/heads/install-on-vanilla-termux.tar.gz \
                     NIX_ON_DROID_FLAKE_URL=github:KoviRobi/nix-on-droid/install-on-vanilla-termux \
                     nix build ".#bootstrapZip-aarch64" --impure
[android:~]$ scp pc:nix-on-droid/result/bootstrap-aarch64.tar.gz .
[android:~]$ mkdir ../nix/
[android:~]$ tar xf ~/bootstrap-aarch64.tar.gz -C ../nix/
[android:~]$ chmod +w -R ../nix/
[android:~]$ ../nix/bin/login
```