### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/emulator.yml
+++ b/.github/workflows/emulator.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build droidctl
         id: droidctl-build
         run: |
-          nix build 'github:t184256/droidctl' --out-link /tmp/droidctl
+          NIXPKGS_ALLOW_UNFREE=1 nix build --impure 'github:t184256/droidctl' --out-link /tmp/droidctl
           echo "path=$(realpath /tmp/droidctl)" >> "$GITHUB_OUTPUT"
 
 
@@ -154,7 +154,7 @@ jobs:
 
       - name: Build droidctl (anew, fallback)
         if: always() && (steps.droidctl-fetch.outcome == 'failure')
-        run: nix build 'github:t184256/droidctl' --out-link /tmp/droidctl
+        run: NIXPKGS_ALLOW_UNFREE=1 nix build --impure 'github:t184256/droidctl' --out-link /tmp/droidctl
 
       - name: Restore AVD cache
         id: avd-cache

--- a/.github/workflows/emulator.yml
+++ b/.github/workflows/emulator.yml
@@ -14,9 +14,12 @@ jobs:
       path: ${{ steps.droidctl-build.outputs.path }}
     steps:
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Configure Nix magic cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@master
+      - name: Configure Nix cache
+        uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build droidctl
         id: droidctl-build
@@ -30,13 +33,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: nixbuild/nix-quick-install-action@master
       - name: Setup cachix
         uses: cachix/cachix-action@v14
         with:
           name: nix-on-droid
-      - name: Configure Nix magic cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Configure Nix cache
+        uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -132,16 +138,19 @@ jobs:
         run: tar xf n-o-d.tar
 
       - name: Install Nix / enable KVM
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Configure Nix magic cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@master
+      - name: Configure Nix cache
+        uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
       - name: Fetch droidctl (using previous eval)
         id: droidctl-fetch
         env:
           DROIDCTL: ${{needs.prepare-droidctl.outputs.path}}
         run: nix build "$DROIDCTL" --out-link /tmp/droidctl
-        continue-on-error: true  # GitHub Actions can throttle magic-nix-cache
+        continue-on-error: true  # GitHub Actions can throttle cache-nix-action
 
       - name: Build droidctl (anew, fallback)
         if: always() && (steps.droidctl-fetch.outcome == 'failure')


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.
