### PR TITLE
nix-on-droid: passthrough --override-input arg

### DIFF
--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -68,6 +68,7 @@ function doHelp() {
     echo "  --keep-going"
     echo "  --max-jobs NUM"
     echo "  --option NAME VALUE"
+    echo "  --override-input INPUT URL"
     echo "  --show-trace"
     echo
     echo "Commands"
@@ -162,7 +163,7 @@ while [[ $# -gt 0 ]]; do
         -n|--dry-run)
             export DRY_RUN=1
             ;;
-        --option)
+        --option|--override-input)
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;


### PR DESCRIPTION
With this addition, we would simplify the development cycle of stylix modules when using flakes:

`nix-on-droid switch --flake . --override-input stylix git+file:/home/user/path/to/stylix`

since we wouldn't need to to do a `nix flake lock --update-input stylix` for every edit to the local stylix input.