### PR TITLE
Add environment.extraSetup

### DIFF
--- a/modules/environment/path.nix
+++ b/modules/environment/path.nix
@@ -34,6 +34,12 @@ in
         example = [ "doc" "info" "devdoc" ];
         description = "List of additional package outputs to be installed as user packages.";
       };
+
+      extraSetup = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Shell fragments to be run after the system environment has been created. This should only be used for things that need to modify the internals of the environment, e.g. generating MIME caches. The environment being built can be accessed at $out.";
+      };
     };
 
   };
@@ -79,6 +85,8 @@ in
         paths = cfg.packages;
 
         inherit (cfg) extraOutputsToInstall;
+
+        postBuild = cfg.extraSetup;
 
         meta = {
           description = "Environment of packages installed through Nix-on-Droid.";


### PR DESCRIPTION
This adds a new option `environment.extraSetup` like the one already in NixOS.

I need this for the same reason as described in the option: to generate MIME cache etc. for desktop environments.