### PR TITLE
Pass class="nixOnDroid"; to evalModules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -25,6 +25,7 @@ let
   rawModule = evalModules {
     modules = [ configModule ] ++ nodModules;
     specialArgs = extraSpecialArgs;
+    class = "nixOnDroid";
   };
 
   failedAssertions = map (x: x.message) (filter (x: !x.assertion) rawModule.config.assertions);

--- a/tests/on-device/config-class.bats
+++ b/tests/on-device/config-class.bats
@@ -1,0 +1,25 @@
+# Copyright (c) 2023, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+load lib
+
+@test 'successfully loads a config with _class="nixOnDroid"' {
+  # set up / build / activate the configuration
+  echo '{ config.system.stateVersion = "24.05"; _class = "nixOnDroid"; }' > ~/.config/nixpkgs/nix-on-droid.nix
+  _sed -e "s|<<FLAKE_URL>>|$FLAKE_URL|g" -e "s|<<SYSTEM>>|$(detect_system)|g" \
+    "$ON_DEVICE_TESTS_DIR/config-flake.nix" \
+    > ~/.config/nixpkgs/flake.nix
+
+  nix-on-droid switch --flake ~/.config/nixpkgs#device
+}
+
+@test 'fails to load a config with _class="nixos"' {
+  # set up / build / activate the configuration
+  echo '{ config.system.stateVersion = "24.05"; _class = "nixos"; }' > ~/.config/nixpkgs/nix-on-droid.nix
+  _sed -e "s|<<FLAKE_URL>>|$FLAKE_URL|g" -e "s|<<SYSTEM>>|$(detect_system)|g" \
+    "$ON_DEVICE_TESTS_DIR/config-flake.nix" \
+    > ~/.config/nixpkgs/flake.nix
+
+  # check that networking.hosts can't map localhost
+  run nix-on-droid switch --flake ~/.config/nixpkgs#device
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
This is useful for getting better error messages when mixing modules; a module designed for nixos configs sets `_class = "nixos";` and then when you try to use it from a nix-on-droid config it shows an error.

See: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-param-class