### PR TITLE
activation: Get activation package with --print-out-paths

### DIFF
--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -101,12 +101,15 @@ function doSwitch() {
     fi
 
     echo "Building activation package..."
-    nixActivationPackage build --no-link
+    generationDir="$(nixActivationPackage build --no-link --print-out-paths | head -n1)"
 
-    echo "Executing activation script..."
-    generationDir="$(nixActivationPackage path-info)"
-
-    "${generationDir}/activate"
+    if [ -n "$generationDir" ] && [ -d "$generationDir" ]; then
+        echo "Executing activation script..."
+        "${generationDir}/activate"
+    else
+        errorEcho "Failed to determine activation package path."
+        return 1
+    fi
 }
 
 function doSwitchGeneration() {


### PR DESCRIPTION
Nix is currently called a second time after the activation package build to find its path in the store. This causes the nix-on-droid config to be evaluated twice, adding overhead and slowing down iteration.

Modern Nix outputs build logs to STDERR and capturing the path from STDOUT should be safe. Only the first line is used in case the config outputs multiple paths for some reason.