### PR TITLE
proot-termux: unstable-2024-05-04 -> unstable-2026-02-20

### DIFF
--- a/modules/environment/login/default.nix
+++ b/modules/environment/login/default.nix
@@ -87,8 +87,8 @@ in
       prootStatic =
         let
           crossCompiledPaths = {
-            aarch64-linux = "/nix/store/7qd99m1w65x2vgqg453nd70y60sm3kay-proot-termux-static-aarch64-unknown-linux-android-unstable-2024-05-04";
-            x86_64-linux = "/nix/store/pakj3svvw84rhkzdc6211yhc2cgvc21f-proot-termux-static-x86_64-unknown-linux-android-unstable-2024-05-04";
+            aarch64-linux = "/nix/store/dvf2ck9bkw7yyrlkjk87xz1anaxsgrd6-proot-termux-static-aarch64-unknown-linux-android-unstable-2026-02-20";
+            x86_64-linux = "/nix/store/w7fksni07fhss7hzkyf4knn5171prj88-proot-termux-static-x86_64-unknown-linux-android-unstable-2026-02-20";
           };
         in
         "${crossCompiledPaths.${targetSystem}}";

--- a/pkgs/bootstrap.nix
+++ b/pkgs/bootstrap.nix
@@ -4,11 +4,13 @@
 
 runCommand "bootstrap" { } ''
   mkdir --parents $out/{.l2s,bin,dev/shm,etc,root,tmp,usr/{bin,lib}}
-  mkdir --parents $out/nix/var/nix/{profiles,gcroots}/per-user/nix-on-droid
+  mkdir --parents $out/nix
 
   cp --recursive ${nixDirectory}/store $out/nix/store
   cp --recursive ${nixDirectory}/var $out/nix/var
   chmod --recursive u+w $out/nix
+
+  mkdir --parents $out/nix/var/nix/{profiles,gcroots}/per-user/nix-on-droid
 
   ln --symbolic ${initialPackageInfo.bash}/bin/sh $out/bin/sh
 

--- a/pkgs/proot-termux/default.nix
+++ b/pkgs/proot-termux/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "proot-termux";
-  version = "unstable-2024-05-04";
+  version = "unstable-2026-02-20";
 
   src = fetchFromGitHub {
     repo = "proot";
     owner = "termux";
-    rev = "60485d2646c1e09105099772da4a20deda8d020d";
-    sha256 = "sha256-zHFPiL3ywZa8yzZa600BpoE+zuRipw2GNJrt3/Dy+/E=";
+    rev = "ab2e3464d04483b98a0614b470f3f8950d5a6468";
+    hash = "sha256-TMYkLmk+NnYcqJKF6RSOkN4S8AI5+HaNcgZZe/5E0vI=";
   };
 
   # ashmem.h is rather small, our needs are even smaller, so just define these:


### PR DESCRIPTION
Fixes #495

The proot-termux update contains patches to fix the TCSETS2 syscall used by `tcgetattr`.

- [add workarounds for TCSETS2 and TCSETSF2](https://github.com/termux/proot/commit/228a5f28b078f4e2504de46758ce17948f73f507)
- [replace TCSETSW2 ioctl with TCSETSW](https://github.com/termux/proot/commit/2cb63b836ad7eae0d7f1fd3c941848a84acb5dcc)
- [replace TCGETS2 ioctl argument with TCGETS](https://github.com/termux/proot/commit/6fa36f7b4405dc08efc87139c0d926a3a3f98fd0)

I have tested this on a fresh nix-on-droid install using the F-Droid apk.  Steps to test: 

1. Unpin the `nixpkgs` input for `nix-on-droid` in your `flake.nix` (assume you pinned to workaround #495)
2. Build `nix build .#prootTermux-x86_64` and `nix build .#prootTermux-aarch64`
3. ~~Copy the proot builds to a public nix cache, put your cache URL and key in `modules/environment/nix.nix`~~
4. Build `nix build ".#bootstrapZip-aarch64" --impure` and copy the resulting .zip to a public https server (http didn't work for me)
5. Clear application data
6. Launch the app, use the URL of your public https server hosting the bootstrap zip when prompted