### PR TITLE
modules: Add `runit` for service management

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -21,6 +21,7 @@
   ./environment/shell.nix
   ./home-manager.nix
   ./nixpkgs/options.nix
+  ./system/service/runit/service.nix
   ./terminal.nix
   ./time.nix
   ./upgrade.nix

--- a/modules/system/service/runit/README.md
+++ b/modules/system/service/runit/README.md
@@ -1,0 +1,273 @@
+# Runit for Nix on Android
+
+Once services are configured correctly the following command may be used to start all;
+
+```bash
+runsvdir ~/../usr/var/service
+```
+
+Within another session check process tree via;
+
+```bash
+ps xf
+```
+
+Each service `NAME` will create directories/files by default under `${config.build.installationDir}/var/service` with the following structure;
+
+- `./run` Required: used to start a service, defined by `runit.services.NAME.execute.run`
+- `./check` Optional: used to customize how service up/down state is checked, defined by `runit.services.NAME.execute.check`
+- `./conf` Not implemented
+- `./finish` Optional: called by runit when `./run` exits, defined by `runit.services.NAME.execute.finish`
+- `./log/config` Optional: used by `svlogd` to modify log behaviors, defined by `runit.services.NAME.svlogd.config` and enabled by `runit.services.NAME.svlogd.enable`
+- `./log/run` Optional: useful for defining CLI arguments for `svlogd` defined by `runit.services.NAME.execute.log.run`
+
+## Examples
+
+### OpenSSH (snippet)
+
+```nix
+      runit.services.sshd = mkIf (config.runit.enable) {
+        package = pkgs.openssh;
+        enable = true;
+        execute = {
+          run = writeScriptBin "service-sshd-run" ''
+            #!${pkgs.runtimeShell}
+
+            ${pkgs.openssh}/bin/ssh-keygen -Af ${config.build.installationDir}
+
+            mkdir -p ${builtins.dirOf cfg.settings.PidFile}
+
+            exec ${pkgs.openssh}/bin/sshd -f "${config.environment.etc."ssh/sshd_config".source}" -De 2>&1
+          '';
+          log.run = writeScriptBin "service-sshd-log" ''
+            #!${pkgs.runtimeShell}
+
+            exec "${config.runit.package.outPath}/bin/svlogd" -tt "${config.runit.settings.environment.svdir}/sshd";
+          '';
+        };
+      };
+```
+
+### OpenSSH modified from `${nixpkgs}/nixos/modules/services/networking/ssh/sshd.nix`
+
+```nix
+{
+  config,
+  lib,
+  nixpkgs,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  inherit (lib)
+    attrValues
+    concatMapStrings
+    concatStringsSep
+    elem
+    filterAttrs
+    flip
+    hasPrefix
+    isList
+    length
+    listToAttrs
+    mapAttrs
+    mkDfault
+    mkIf
+    nameValuePair
+    readFile
+    removeAttrs
+    ;
+
+  inherit (pkgs)
+    writeScriptBin
+    ;
+
+  mod = {
+    sshd = import "${nixpkgs}/nixos/modules/services/networking/ssh/sshd.nix" {
+      inherit
+        config
+        lib
+        pkgs
+        ;
+    };
+  };
+
+  settingsFormat =
+    let
+      # reports boolean as yes / no
+      mkValueString = with lib; v:
+            if isInt           v then toString v
+            else if isString   v then v
+            else if true  ==   v then "yes"
+            else if false ==   v then "no"
+            else throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty {}) v}";
+
+      base = pkgs.formats.keyValue {
+        mkKeyValue = lib.generators.mkKeyValueDefault { inherit mkValueString; } " ";
+      };
+      # OpenSSH is very inconsistent with options that can take multiple values.
+      # For some of them, they can simply appear multiple times and are appended, for others the
+      # values must be separated by whitespace or even commas.
+      # Consult either sshd_config(5) or, as last resort, the OpehSSH source for parsing
+      # the options at servconf.c:process_server_config_line_depth() to determine the right "mode"
+      # for each. But fortunaly this fact is documented for most of them in the manpage.
+      commaSeparated = [ "Ciphers" "KexAlgorithms" "Macs" ];
+      spaceSeparated = [ "AuthorizedKeysFile" "AllowGroups" "AllowUsers" "DenyGroups" "DenyUsers" ];
+    in {
+      inherit (base) type;
+      generate = name: value:
+        let transformedValue = mapAttrs (key: val:
+          if isList val then
+            if elem key commaSeparated then concatStringsSep "," val
+            else if elem key spaceSeparated then concatStringsSep " " val
+            else throw "list value for unknown key ${key}: ${(lib.generators.toPretty {}) val}"
+          else
+            val
+          ) value;
+        in
+          base.generate name transformedValue;
+    };
+
+  configFile = settingsFormat.generate "sshd.conf-settings" (filterAttrs (n: v: v != null) cfg.settings);
+  sshconf = pkgs.runCommand "sshd.conf-final" { } ''
+    cat ${configFile} - >$out <<EOL
+    ${cfg.extraConfig}
+    EOL
+  '';
+
+
+  cfg = config.services.openssh;
+
+  prepend_build_installationDir = path: "${cfg.build.installationDir}/${path}";
+in
+{
+  options.services.openssh = mod.sshd.options.services.openssh // {
+    generateHostKeys.default = mkDfault false;
+    generateHostKeys.description = concatStringsSep "\n\n" [
+      mod.sshd.options.services.openssh.generateHostKeys.description
+      ''
+        Nix on Droid defaults to `false` to disable;
+
+        - `config.systemd.services."sshd@"`
+        - `config.systemd.services.sshd`
+        - `config.systemd.services.sshd-keygen`
+      ''
+    ];
+
+    openFirewall.default = mkDfault false;
+    openFirewall.description = concatStringsSep "\n\n" [
+      mod.sshd.options.services.openssh.openFirewall.description
+      ''
+        Nix on Droid defaults to `false` to disable;
+
+        - `config.networking.firewall.allowedTCPPorts`
+      ''
+    ];
+
+    hostKeys.default = lib.map (attrs: attrs // {
+      path = prepend_build_installationDir attrs.path;
+    }) mod.sshd.options.services.openssh.hostKeys.default;
+    hostKeys.description = concatStringsSep "\n\n" [
+      mod.sshd.options.services.openssh.hostKeys.description
+      ''
+        Nix on Droid pre-pends `"''${cfg.build.installationDir}/"` to each `path` in list of attributes
+      ''
+    ];
+  };
+
+  config =
+    let
+      sshdConfigContentFiltered = (removeAttrs mod.sshd.config.content [
+        ## Requires `users.users` which requires `boot.initrd.enable`
+        "users"
+        "environment"
+        "security"
+
+        ## Requires `networking.firewall`
+        "networking"
+
+        ## Requires SystemD which assumes Root and boot stuff
+        "systemd"
+
+        ## Skipping `system.checks`
+        "system"
+      ]);
+    in
+    mkIf cfg.enable (sshdConfigContentFiltered // {
+      environment.etc = {
+        # "ssh/moduli".source = cfg.moduliFile;
+        "ssh/sshd_config".source = sshconf;
+      };
+
+      services.openssh.authorizedKeysFiles =
+        lib.optional cfg.authorizedKeysInHomedir
+          lib.map (path:
+            if hasPrefix "/etc/ssh" path then
+              prepend_build_installationDir path
+            else
+              path
+          ) sshdConfigContentFiltered.services.openssh.authorizedKeysFiles;
+
+      services.openssh.settings.AuthorizedPrincipalsFile =
+        mkIf (sshdConfigContentFiltered.services.openssh ? "AuthorizedPrincipalsFile" && sshdConfigContentFiltered.services.openssh.AuthorizedPrincipalsFile != {})
+          (prepend_build_installationDir sshdConfigContentFiltered.services.openssh.AuthorizedPrincipalsFile)
+          ;
+
+      ## TODO: Get clever about modifying submodule
+      services.openssh.settings.PidFile = "${config.build.installationDir}/run/sshd.pid";
+      services.openssh.settings.UsePAM = false;
+
+      ## Define `runit` integration here!
+      runit.services.sshd = mkIf (config.runit.enable) {
+        package = pkgs.openssh;
+        enable = true;
+        execute = {
+          run = writeScriptBin "service-sshd-run" ''
+            #!${pkgs.runtimeShell}
+
+            ${pkgs.openssh}/bin/ssh-keygen -Af ${config.build.installationDir}
+
+            mkdir -p "${builtins.dirOf cfg.settings.PidFile}"
+
+            exec ${pkgs.openssh}/bin/sshd -f "${config.environment.etc."ssh/sshd_config".source}" -De 2>&1
+          '';
+          log.run = writeScriptBin "service-sshd-log" ''
+            #!${pkgs.runtimeShell}
+
+            exec "${config.runit.package.outPath}/bin/svlogd" -tt "${config.runit.settings.environment.svdir}/sshd";
+          '';
+        };
+      };
+    });
+}
+```
+
+## Notes and Warnings
+
+- Replacing system init is **not** tested, however, most of the `options` _should_ be defined for those that wish to test this
+- This module is likely incompatible with upstream NixOS, for now, and assistance is welcomed for making this compatible with upstream NixOS packages
+- NixOS defines `systemd` options, such as `serviceConfig.ExecStart`, which could be _borrowed_ by this module. But no plans, currently, are planned to automate this
+- Currently no `/home/username` options are provided for defining user-level services with `runit`
+
+______
+
+## Attributions
+
+- [Arch Wiki -- Runit](https://wiki.artixlinux.org/Main/Runit)
+- [Gentoo Wiki -- runit](https://wiki.gentoo.org/wiki/Runit)
+- [GitHub -- `NixOS/nixpkgs` -- Issue 24346 -- Can I replace systemd with OpenRC or runit on NixOS?](https://github.com/NixOS/nixpkgs/issues/24346)
+- [GitHub -- `cleverca22/not-os` -- `master:./runit.nix`](https://github.com/cleverca22/not-os/blob/master/runit.nix)
+- [GitHub -- `rubyists/runit-services`](https://github.com/rubyists/runit-services/)
+- [GitHub -- `termux/termux-packages` -- Issue 17 -- unable to open supervise/ok: file does not exist](https://github.com/termux/termux-services/issues/17)
+- [GitHub -- `termux/termux-packages` -- Issue 25479 [Bug]: sv enbable `<service_name>` fails with "file does not exist" despite directory existing](https://github.com/termux/termux-packages/issues/25479)
+- [GitHub -- `termux/termux-packages` -- Issue 25861 -- [Bug]: OpenSSH package doesn't check whether sshd and ssh-agent are enabled during preinstall, both get disabled after every upgrade](https://github.com/termux/termux-packages/issues/25861)
+- [GitHub -- `termux/termux-packages` -- v0.14](https://github.com/termux/termux-services/blob/0.14)
+- [GitHub Pages -- kchard -- runit-quickstart](https://kchard.github.io/runit-quickstart/)
+- [Medium -- mrinjamul -- Create and manage services in Termux (Linux-based Android Terminal)](https://mrinjamul.medium.com/create-and-manage-services-in-termux-linux-based-android-terminal-5120c4694199)
+- [NixOS Discourse -- Setting an environment variable for a single package?](https://discourse.nixos.org/t/setting-an-environment-variable-for-a-single-package/15075/6)
+- [Termux Wiki -- Termux-services](https://wiki.termux.com/wiki/Termux-services)
+- [Void Linux Docs -- Services and Daemons -- runit](https://docs.voidlinux.org/config/services/index.html)
+- [YouTube -- Joseph Choe -- Running with runit!](https://www.youtube.com/watch?v=8dGHkFCmosU)
+- [smarden -- `runit/sv.8`](https://smarden.org/runit/sv.8)
+- [smarden -- `runit`](https://smarden.org/runit/)

--- a/modules/system/service/runit/service.nix
+++ b/modules/system/service/runit/service.nix
@@ -1,0 +1,733 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  inherit (builtins)
+    toString
+    ;
+
+  inherit (lib)
+    attrByPath
+    attrValues
+    concatStringsSep
+    filterAttrs
+    getExe
+    literalExpression
+    mapAttrs
+    mkEnableOption
+    mkIf
+    mkOption
+    optionalString
+    optionals
+    typeOf
+    ;
+
+  inherit (lib.types)
+    attrsOf
+    int
+    either
+    nonEmptyStr
+    nullOr
+    package
+    path
+    submodule
+    ;
+
+  inherit (pkgs)
+    makeWrapper
+    runit
+    writeTextFile
+    ;
+
+  inherit (pkgs.stdenv)
+    mkDerivation
+    ;
+
+  mkService =
+    { name, ... }:
+    let
+      control = mkOption {
+        description = ''
+          [man rusv -- Control](https://smarden.org/runit1/runsv.8#sect3)
+
+          Services have a named pipe under `''${config.runit.settings.environment.svdir}/NAME/supervise/control`
+          Logs have a named pipe under `''${config.runit.settings.environment.svdir}/NAME/log/supervise/control`
+
+          These named pipes when written to with a given control character may call associated executable.
+        '';
+
+        example = literalExpression ''
+          ## Service control
+          runit.services.NAME.control.u = '''
+            #!''${pkgs.runtimeShell}
+
+            _exe_basename="''${pkgs.coreutils.outPath}/bin/basename";
+            _exe_dirname="''${pkgs.coreutils.outPath}/bin/dirname";
+
+            _name="$("$_exe_basename" "$("$_exe_dirname" "$PWD")")";
+
+            echo "control/u called for: $_name";
+          '''
+
+          ## Log control
+          runit.services.NAME.log.control.u = '''
+            #!''${pkgs.runtimeShell}
+
+            _exe_basename="''${pkgs.coreutils.outPath}/bin/basename";
+            _exe_dirname="''${pkgs.coreutils.outPath}/bin/dirname";
+
+            _parent="$("$_exe_basename" "$("$_exe_dirname" "$PWD")")";
+            _name="$("$_exe_basename" "$_parent")";
+
+            echo "control/u called for: $_name/log";
+          '''
+        '';
+
+        default = { };
+        type = submodule {
+          options = {
+            u = mkOption {
+              description = ''
+                Up. If the service is not running, start it. If the sesrvice stops, restart it.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            d = mkOption {
+              description = ''
+                Down. If the service is running, send it a TERM signal. If `./run` exits, start `./finish` if it exists. After it stops, do not restart service.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            o = mkOption {
+              description = ''
+                Once. If the service is not running, start it. Do not restart it if it stops.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            p = mkOption {
+              description = ''
+                Pause. If the service is running, send it a STOP signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            c = mkOption {
+              description = ''
+                Continue. If the service is running, send it a CONT signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            h = mkOption {
+              description = ''
+                Hangup. If the service is running, send it a HUP signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            a = mkOption {
+              description = ''
+                Alarm. If the service is running, send it a ALRM signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            i = mkOption {
+              description = ''
+                Interrupt. If the service is running, send it a INT signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            q = mkOption {
+              description = ''
+                Quit. If the service is running, send it a QUIT signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            "1" = mkOption {
+              description = ''
+                If the service is running, send it a USR1 signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            "2" = mkOption {
+              description = ''
+                If the service is running, send it a USR2 signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            k = mkOption {
+              description = ''
+                Kill. If the service is running, send it a KILL signal.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            x = mkOption {
+              description = ''
+                Exit. If the service is running, send it a TERM signal.
+
+                Aliase of `e`, check `e` for more documentation and examples.
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+            e = mkOption {
+              description = ''
+                Exit. If the service is running, send it a TERM signal.
+                Aliase of `x`
+
+                Do not restart the service. If the service is down, and no log service exists, `runsv` exits.
+
+                If the service is down and a log service exits, `runsv` closes the standard input of the log service, and waits for it to terminate.
+
+                If the log sservice is down, `runsv` exits.
+
+                This command is ignored if it is given to the `service/log/supervise/control`
+
+                Example: to send a TERM signal to the socklog-unix service, either do `runsvctrl term ''${runit.settings.environment.svdir}/socklog-unix`
+
+                or
+
+                `echo -n t >''${runit.settings.environment.svdir}/socklog-unix/supervise/control`
+              '';
+              type = nullOr nonEmptyStr;
+              default = null;
+            };
+          };
+        };
+      };
+    in
+    {
+      options = {
+        enable = mkEnableOption "Enable named service executables";
+
+        package = mkOption {
+          type = nullOr package;
+          description = "Package to have `runit` monitor/start/stop";
+        };
+
+        svlogd = mkOption {
+          description = ''
+            See: https://smarden.org/runit/svlogd.8
+          '';
+
+          example = literalExpression ''
+            See: https://smarden.org/runit/svlogd.8
+
+            runit.services.NAME.svlogd = {
+              enable = true;
+              config = '''
+                # Max file size
+                s1000000
+                # Number of log files to keep
+                n10
+                # Minimum number of old log files to maintain, must be less than `n`
+                N10
+                # Max age in seconds of current log file before rotating
+                t41968
+                # ...
+              ''';
+            };
+          '';
+
+          default = { };
+          type = submodule {
+            options = {
+              enable = mkEnableOption "Enable svlogd for named service";
+
+              config = mkOption {
+                description = ''
+                  May be multi-line string defining configurations, or path to preexisting configuration file
+
+                  See: https://smarden.org/runit/svlogd.8#config
+                '';
+                default = null;
+                type = nullOr (either nonEmptyStr path);
+              };
+            };
+          };
+        };
+
+        execute = mkOption {
+          description = ''
+            Executables that may be called for starting, stopping, logging, and control signals of named service.
+          '';
+
+          type = submodule {
+            options = {
+              inherit control;
+
+              run = mkOption {
+                description = "Script that `sv` will call for starting service";
+
+                example = literalExpression ''
+                  runit.services.sshd.log = writeScriptBin "service-sshd-run" '''
+                    #!''${pkgs.runtimeShell}
+
+                    ''${pkgs.openssh}/bin/ssh-keygen -Af ''${config.build.installationDir}
+
+                    mkdir -p ''${builtins.dirOf cfg.settings.PidFile}
+
+                    exec ''${pkgs.openssh}/bin/sshd -f "''${config.environment.etc."ssh/sshd_config".source}" -De 2>&1
+                  '''
+                '';
+
+                type = package;
+              };
+
+              check = mkOption {
+                description = ''
+                  Executable `sv` will call to check service is in given up/down state
+
+                  See: https://smarden.org/runit/sv.8#additional-commands
+                '';
+
+                example = literalExpression ''
+                  runit.services.sshd.check = writeScriptBin "service-sshd-check" '''
+                    #!''${pkgs.runtimeShell}
+
+                    printf 'service-sshd-check called';
+                    env;
+                    printf '%s\n' "''${@}";
+                  '''
+                '';
+
+                type = package;
+              };
+
+              finish = mkOption {
+                description = "Script that `sv` will call for stopping service";
+
+                example = literalExpression ''
+                  runit.services.sshd.log = writeScriptBin "service-sshd-finish" '''
+                    #!''${pkgs.runtimeShell}
+
+                    _exe_basename="''${pkgs.coreutils.outPath}/bin/basename";
+                    _exe_dirname="''${pkgs.coreutils.outPath}/bin/dirname";
+
+                    _name="$("$_exe_basename" "$("$_exe_dirname" "$PWD")")";
+
+                    env;
+                    echo "FINISED: _name -> $_name";
+                  '''
+                '';
+
+                type = nullOr package;
+                default = null;
+              };
+
+              log = mkOption {
+                default = { };
+                type = submodule {
+                  options = {
+                    inherit control;
+
+                    run = mkOption {
+                      description = ''
+                        Script that `sv` will call for logging service.
+
+                        See: https://smarden.org/runit/svlogd.8
+                      '';
+
+                      example = literalExpression ''
+                        runit.services.sshd.log.run = writeScriptBin "service-sshd-log-run" '''
+                          #!''${pkgs.runtimeShell}
+
+                          exec "''${config.runit.package.outPath}/bin/svlogd" -tt "''${config.runit.settings.environment.svdir}/__NAME__";
+                        '''
+                      '';
+
+                      type = nullOr package;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+
+  cfg = config.runit;
+in
+{
+  options.runit = {
+    enable = mkEnableOption "Enable runit configuration management";
+
+    package = mkOption {
+      description = ''
+        Package that will be used with module and modified to include `config.runit.settings.environment.svdir`
+      '';
+
+      example = literalExpression ''
+        package = pkgs.runit.overrideAttrs (oldAttrs: { ... });
+      '';
+
+      default = runit;
+      type = package;
+    };
+
+    settings = mkOption {
+      description = "";
+
+      example = literalExpression ''
+        runit.settings = {
+          environment = {
+            svdir = "''${config.build.installationDir}/var/service";
+            logdir = "''${config.build.installationDir}/var/log";
+            svwait = 7;
+          };
+        };
+      '';
+
+      default = { };
+      type = submodule {
+        options = {
+          environment = mkOption {
+            description = ''
+              Environment variables that will be set via `wrapProgram` on all `''${config.package.outPath}/bin` executables
+            '';
+
+            default = { };
+            type = submodule {
+              options = {
+                svdir = mkOption {
+                  description = ''
+                    Where files in `config.runit.service.NAME` will be linked to for `runit`
+                  '';
+                  type = nonEmptyStr;
+                  default = "${config.build.installationDir}/var/service";
+                };
+
+                logdir = mkOption {
+                  description = ''
+                    Where logs in `config.runit.service.NAME` will be read/written for `runit`
+
+                    TODO: double-check this is correct!
+                  '';
+                  type = nonEmptyStr;
+                  default = "${config.build.installationDir}/var/log";
+                };
+
+                svwait = mkOption {
+                  description = ''
+                    See: https://manpages.debian.org/unstable/runit/sv.8.en.html#SVWAIT
+                  '';
+                  type = nullOr int;
+                  default = null;
+                };
+              };
+            };
+          };
+
+          init = mkOption {
+            description = ''
+              WARNING: untested!
+
+              See: https://smarden.org/runit/replaceinit
+            '';
+
+            example = literalExpression ''
+              runit.settings.init = {
+                enable = true;
+
+                dir = "''${config.build.installationDir}/etc/runit";
+
+                getty-5.dir = "''${config.build.installationDir}/sv/getty-5";
+
+                executables = {
+                 "1" = writeScriptBin "runnit-system-boot" '''
+                   # ...
+                 ''';
+
+                 "2" = writeScriptBin "runnit-system-run" '''
+                   # ...
+                 ''';
+
+                 "2" = writeScriptBin "runnit-system-shutdown" '''
+                   # ...
+                 ''';
+                };
+              };
+            '';
+
+            default = { };
+            type = submodule {
+              options = {
+                enable = mkEnableOption "Enable using runit as system init";
+
+                description = ''
+                  WARNING: untested!
+
+                  See: https://smarden.org/runit/replaceinit
+                '';
+
+                dir = mkOption {
+                  description = ''
+                    Directory `sysvinit` checks for system booting, running, and shutdown
+                  '';
+
+                  example = literalExpression ''
+                    runit.settings.init.dir = "''${config.build.installationDir}/etc/runit";
+                  '';
+
+                  type = nonEmptyStr;
+                  default = "${config.build.installationDir}/etc/runit";
+                };
+
+                executables = mkOption {
+                  type = submodule {
+                    options = {
+                      "1" = mkOption {
+                        description = ''
+                          System booting executable
+                        '';
+                        # example = literalExpression ''
+                        # '';
+                        type = nullOr package;
+                        default = null;
+                      };
+
+                      "2" = mkOption {
+                        description = ''
+                          System running executable
+                        '';
+                        type = nullOr package;
+                        default = null;
+                      };
+
+                      "3" = mkOption {
+                        description = ''
+                          System shutdown executable
+                        '';
+                        type = nullOr package;
+                        default = null;
+                      };
+
+                      ctrlaltdel = mkOption {
+                        description = ''
+                          Handle ctrl-alt-del keyboard request
+                        '';
+                        type = nullOr package;
+                        default = null;
+                      };
+                    };
+                  };
+                };
+
+                getty-5 = mkOption {
+                  description = ''
+                    WARNING: untested!
+
+                    See: https://github.com/NixOS/nixpkgs/blob/8c91a71d13451abc40eb9dae8910f972f979852f/nixos/modules/services/ttys/getty.nix
+                  '';
+                  example = ''
+                    runit.settings.init.getty-5.service = {
+                      enable = true;
+                      package = lib.getExe' pkgs.util-linux "agetty";
+                      # ...
+                    };
+                  '';
+                  type = attrsOf (submodule (inputs: mkService (inputs // { name = "service"; })));
+                };
+              };
+            };
+          };
+
+          ## TODO: Find less hacky way of avoiding rebuild from source
+          packageWrapped = mkOption {
+            description = ''
+              Internal hacky mkDerivation modification used to avoid re-building `runit.package` from source
+            '';
+
+            example = literalExpression ''
+              package = pkgs.runit.overrideAttrs (oldAttrs: { ... });
+            '';
+
+            default = mkDerivation {
+              inherit (cfg.package) src;
+              name = "NoD-wrapped-${cfg.package.pname}";
+              version = "${cfg.package.version}-NoD-wrapped";
+              nativeBuildInputs = [ makeWrapper ];
+              installPhase =
+                let
+                  environment-setters = concatStringsSep " " (
+                    [
+                      "--set SVDIR '${cfg.settings.environment.svdir}'"
+                      "--set LOGDIR '${cfg.settings.environment.logdir}'"
+                    ]
+                    ++ (optionals (cfg.settings.environment.svwait != null) [
+                      "--set SVWAIT '${toString cfg.settings.environment.svwait}'"
+                    ])
+                  );
+                in
+                ''
+                  mkdir -p $out/bin;
+
+                  while read -rd "" _executable; do
+                    ln -sfv "$_executable" "$out/bin/";
+
+                    wrapProgram "$out/bin/''${_executable##*/}" ${environment-setters};
+                  done < <("${pkgs.lib.getExe pkgs.findutils}" "${cfg.package.outPath}/bin" -maxdepth 1 -type f -executable -print0)
+                '';
+            };
+            type = package;
+          };
+        };
+      };
+    };
+
+    services = mkOption {
+      description = "";
+
+      example = literalExpression ''
+        services.sshd = {
+          package = pkgs.openssh;
+          name = "sshd";
+          run-up = '''
+            #!''${pkgs.runtimeShell}
+            exec ''${pkgs.openssh}/bin/sshd -f "''${config.environment.etc."ssh/sshd_config".outPatn}" -De 2>&1
+          ''';
+        };
+      '';
+
+      type = attrsOf (submodule mkService);
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.packages = [ cfg.settings.packageWrapped ];
+
+    ## This does not seem to work, not without further investigation/fiddling
+    # environment.sessionVariables = {
+    #   SVDIR = cfg.settings.environment.svdir;
+    # };
+
+    ## nix-community/nix-on-droid -> modules/build/activation.nix
+    build.activation =
+      let
+        services = mkIf (cfg.services != { }) (
+          mapAttrs
+            (
+              name: service:
+                let
+                  package-check = attrByPath [ "execute" "check" ] null service;
+                  package-finish = attrByPath [ "execute" "finish" ] null service;
+                  package-log-run = attrByPath [ "execute" "log" "run" ] null service;
+
+                  controlMappedToLink =
+                    { directory, control-config }:
+                    mapAttrs
+                      (character: package: ''
+                        $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${getExe package}" "${directory}/${character}";
+                      '')
+                      (filterAttrs (_name: package: package != null) control-config);
+
+                  control-service-links = controlMappedToLink {
+                    directory = "${cfg.settings.environment.svdir}/${name}/control";
+                    control-config = service.execute.control;
+                  };
+
+                  control-log-links = controlMappedToLink {
+                    directory = "${cfg.settings.environment.svdir}/${name}/log/control";
+                    control-config = control-service-links;
+                  };
+
+                  svlogd-config = optionalString (service.svlogd.enable && service.svlogd.config != null) (
+                    if (typeOf service.svlogd.config) == "path" then
+                      ''
+                        $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${service.svlogd.config}" "${cfg.settings.environment.svdir}/${name}/log/config";
+                      ''
+                    else if (typeOf service.svlogd.config) == "string" then
+                      ''
+                        $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${
+                          (writeTextFile {
+                            name = "svlogd-${name}";
+                            text = service.svlogd.config;
+                          }).outPath
+                        }" "${cfg.settings.environment.svdir}/${name}/log/config";
+                      ''
+                    else
+                      throw "`runit.services.${name}.svlogd.config` is neither `string` or `path` type"
+                  );
+                in
+                ''
+                  ## Where log files will be written?
+                  $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents "${cfg.settings.environment.logdir}/${name}";
+
+                  $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents "${cfg.settings.environment.svdir}/${name}/log";
+
+                  ## pid and lock files expected to live here
+                  $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents "${cfg.settings.environment.svdir}/${name}/supervise";
+
+                  ## `./run` executable expected to be here for starting
+                  $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${getExe service.execute.run}" "${cfg.settings.environment.svdir}/${name}/run";
+                ''
+                + optionalString (package-check != null) ''
+                  ## `./check` executable expected to be to modify how `sv` checks for service states
+                  $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${getExe package-check}" "${cfg.settings.environment.svdir}/${name}/check";
+                ''
+                + optionalString (package-finish != null) ''
+                  ## `./finish` executable expected to be here when `${name}/run` exits
+                  $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${getExe package-finish}" "${cfg.settings.environment.svdir}/${name}/finish";
+                ''
+                + optionalString (package-log-run != null) ''
+                  ## `./log/run` executable expected to be here for logging
+                  $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${getExe package-log-run}" "${cfg.settings.environment.svdir}/${name}/log/run";
+                ''
+                + optionalString (service.execute.control != { }) ''
+                  $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents "${cfg.settings.environment.svdir}/${name}/control";
+                  ${concatStringsSep "\n" (attrValues control-service-links)}
+                ''
+                + optionalString (service.execute.log.control != { }) ''
+                  $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents "${cfg.settings.environment.svdir}/${name}/log/control";
+                  ${concatStringsSep "\n" (attrValues control-log-links)}
+                ''
+                + optionalString service.svlogd.enable ''
+                  ${svlogd-config}
+                ''
+            )
+            (filterAttrs (_name: service: service.enable) cfg.services)
+        );
+
+        init = mkIf cfg.settings.init.enable {
+          setup =
+            let
+              init-executables = mapAttrs
+                (
+                  name: executable:
+                    if executable != null then
+                      ''
+                        $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${getExe executable}" "${cfg.settings.init.dir}/${name}";
+                      ''
+                    else
+                      lib.warn ''
+                        Missing runit system init executable: ${name}
+
+                        Your system may not be correctly configured, please check the description;
+                        ${cfg.settings.init.executables.${name}.description}
+                      '' ""
+                )
+                cfg.settings.init.executables;
+
+            in
+            ''
+              ## Runit system init
+              $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents "${cfg.settings.init.dir}";
+              ${concatStringsSep "\n" (attrValues init-executables)}
+            '';
+        };
+      in
+      services // init;
+  };
+}


### PR DESCRIPTION
Long story short, Termux uses `runit` and (many hours/days) ago I thought it'd be easy/fun to get `runit` running with Nix on Droid x-]

Runit runs!... but, likely there are changes needed before this PR will be in an acceptable state

The added `modules/system/service/runit/README.md` provides a fully functional, albeit cringy, example of how I've got OpenSSH running with Runnit on an old Android device

The added `modules/system/service/runit/service.nix` file defines most of the options I could figure-out from spending quality time with related man-pages. Please check the related ReadMe's Notes/Warnings section for some notes and warnings

I'm not quite certain how best to link/load this module into the rest of the `config` name-space, and would much appreciate some assistance so no toes get stomped

## Updates and edits

### 2026-07-07

I'm not sure how to satisfy the CI/CD

Also am unsure if `runit-init` command will function as official docs advertise, I've not been able to make it happy

Also also am reasonably sure the following work-around is less than ideal for launching `runsvdir` automatically;

`flake.nix` (snippet)

```nix
  outputs = { self, home-manager, nixpkgs, nix-on-droid }@inputs:
  {
    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
      modules = [
        (
          { config, ... }:
          {
            home-manager = {
              extraSpecialArgs = {
                inherit pkgs;
                ## Forced even though it _should_ be set already
                osConfig = config;
              };

              # ... other configs for home-manager
            };
          }
        )
      ];
      # ... other configs for system
    };
  };
```

Home manager snippet

```nix
{
  config,
  lib,
  osConfig,
  ...
}:
{
  config.programs.bash = lib.mkIf config.programs.bash.enable {
    ## Extra commands to append to bashrc file
    bashrcExtra =
      ''
        # setup environment for non interactive sessions
        source "$HOME/.nix-profile/etc/profile.d/nix-on-droid-session-init.sh"
      ''
      + lib.optionalString osConfig.runit.enable ''
        # Who needs a daemon or full Init?!
        if ! pidof runsvdir >/dev/null 2>&1; then
          nohup runsvdir "${osConfig.runit.settings.environment.svdir}" >"${osConfig.runit.settings.environment.logdir}/runsvdir.log" 2>&1 &
          disown %1
        fi
      ''
      + ''
        # Commands that should be applied only for interactive shells.
        [[ $- == *i* ]] || return
      ''
      # ... other shell setup stuff
      ;
  };
}
```
